### PR TITLE
Corretto posizionamento argomenti in alcune semctl

### DIFF
--- a/ambiente_globale/produttore_consumatore/produttore-consumatore_con_vettore_di_stato_con_semafori/clienti.c
+++ b/ambiente_globale/produttore_consumatore/produttore-consumatore_con_vettore_di_stato_con_semafori/clienti.c
@@ -74,7 +74,7 @@ int main() {
 		wait(&status);
 	}
 
-	semctl(id_sem, IPC_RMID, 0);
+	semctl(id_sem, 0, IPC_RMID);
 	shmctl(id_mem, IPC_RMID, 0);
 
 	return 0;

--- a/ambiente_globale/produttore_consumatore/produttore-consumatore_con_vettore_di_stato_con_semafori/visualizzatore.c
+++ b/ambiente_globale/produttore_consumatore/produttore-consumatore_con_vettore_di_stato_con_semafori/visualizzatore.c
@@ -69,7 +69,7 @@ int main() {
 		sleep(1);
 	}
 
-	semctl(id_sem, IPC_RMID, 0);
+	semctl(id_sem, 0, IPC_RMID);
 	shmctl(id_mem, IPC_RMID, 0);
 
 	return 0;


### PR DESCRIPTION
In alcune `semctl(...)` gli argomenti `semnum` e `op` erano invertiti, presentandosi in questo modo:

```c
semctl(id_sem, IPC_RMID, 0);
```
invece che in [questo](https://man7.org/linux/man-pages/man2/semctl.2.html):

```c
semctl(id_sem, 0, IPC_RMID);
```

Le chiamate avevano comunque il comportamento desiderato perché `IPC_RMID = 0` e qundi entrambe le versioni sono equivalenti a:

```c
semctl(id_sem, 0, 0);
```

L'effetto della PR è quello di rendere semanticamente più coerenti le chiamate